### PR TITLE
Issue 301 patch

### DIFF
--- a/ConvertCSV/src/org/openintents/convertcsv/notepad/ImportCsv.java
+++ b/ConvertCSV/src/org/openintents/convertcsv/notepad/ImportCsv.java
@@ -129,7 +129,7 @@ public class ImportCsv {
 	    	// Do we need to overwrite or ignore this?
 	    	if (needToValidate) {
 	    		// We need to identify it by title.
-	    		String title = NotepadUtils.extractTitle(note);
+	    		String title = NotepadUtils.extractTitle(note, encrypted);
 		    	int existingNoteId = NotepadUtils.findNoteByTitle(mContext, title);
 		    	
 		    	if (existingNoteId != -1) {

--- a/ConvertCSV/src/org/openintents/convertcsv/notepad/NotepadUtils.java
+++ b/ConvertCSV/src/org/openintents/convertcsv/notepad/NotepadUtils.java
@@ -48,7 +48,7 @@ public class NotepadUtils {
 		// Add item to list:
 		ContentValues values = new ContentValues(1);
 		values.put(NotePad.Notes.NOTE, note);
-		String title = extractTitle(note);
+		String title = extractTitle(note, encrypted);
 		values.put(NotePad.Notes.TITLE, title);
 		
 		if (COLUMN_INDEX_ENCRYPTED > -1) {
@@ -69,9 +69,9 @@ public class NotepadUtils {
 		}
 	}
 	
-	public static String extractTitle(String note) {
+	public static String extractTitle(String note, long encrypted) {
         int length = note.length();
-		String title = note.substring(0, Math.min(30, length));
+		String title = (encrypted > 0)? note : note.substring(0, Math.min(30, length));
         // Break at newline:
         int firstNewline = title.indexOf('\n');
         if (firstNewline > 0) {


### PR DESCRIPTION
This contains the patch which fixes Issue 301 where encrypted titles are not displayed in the list of notes.

Cause:
This is caused because of the function extractTitle in class NotepadUtils present in the 
package org.openintents.convertcsv.notepad;
The function does not take into account that the title might be encrypted and thus just takes the title 
if it is less than 30 characters or the first 30 characters of the title.Now since the cipher is a 128 character string, it
just returns the first 30 characters of the cipher and that is being added as the note in the database.Since,the 
incorrect encrypted string is passed, OISafe cannot decode the title and thus, title is displayed as blank.

Solution:
Pass the encrypted long value as a parameter to the extractTitle method.
